### PR TITLE
Fixes for pseudoDashes()

### DIFF
--- a/code/lib.js
+++ b/code/lib.js
@@ -275,6 +275,9 @@ function pseudos(plain_lists) {
 
 	/* Converts custom HTML entity names to their corresponding entities */
 	customHtmlEntities();
+
+	/* Converts pseudo-dashes (--, ---, etc.) to real dashes */
+	pseudoDashes(); 
 }
 
 var supKbdCharacters = "0123456789+-=()ABDEGHIJKLMNOPRTUVWabcdefghijklmnoprstuvwxyzβγδθιψχɒɕðɜɟɡɥɨɩɪʝɭʟɱɰɲɳɴɵɸʂʃʉʊʋʌʐʑʒθɐɑɛŋɔɯ";
@@ -319,6 +322,15 @@ function customHtmlEntities() {
 		temp = arr.join(entities[i]);
 	}
 	document.body.innerHTML = temp;
+}
+
+function pseudoDashes() {
+ document.body.innerHTML = document.body.innerHTML
+ .replace(/----/g,"―")
+ .replace(/---/g,"—")
+ .replace(/--/g,"–")
+ .replace(/ - /g," ⁃ ")
+ .replace(/	- /g, "	⁃ "); 
 }
 
 /*


### PR DESCRIPTION
Reordered pseudoDashes code to go largest to smallest and added hyphen
bullet.

The available pseudoDashes are as follows:
- Four hyphens (----) are replaced by a quotation dash
- Three hyphens (---) are replaced by an m-dash
- Two hyphens (--) are replaced by an n-dash
- A single hyphen between two whitespace characters (a tab or space on
the left and a space on the right) is replaced by a hyphen bullet