### PR TITLE
Disabled fixTypography

### DIFF
--- a/code/lib.js
+++ b/code/lib.js
@@ -390,10 +390,14 @@ function pseudos(plain_lists) {
 	/* Converts pseudo-dashes (--, ---, etc.) to real dashes */
 	pseudoDashes();
 
-	/* Changes dumb quotes to smart quotes and ellipses to the ellipses character */
-	fixTypography();
 }
 
+/* Changes dumb quotes to smart quotes and ellipses to 
+ * the ellipses character.
+ * Currently, it does this inside HTML tags too, so it
+ * breaks everything. I'm leaving it here so I can fix 
+ * it later.
+ */
 function fixTypography() {
  var str = document.body.innerHTML;
 


### PR DESCRIPTION
The fixTypography function was converting single and double quotes into smart quotes in the code too, so it was breaking everything. I'll fix it later, but for now I'm just taking it out of the main function.